### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "config": "^3.0.1",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.5.0",
-    "mongoose": "^5.1.6",
-    "npm": "^6.9.0"
+    "mongoose": "^5.1.6"
   },
   "devDependencies": {
     "nodemon": "^1.17.5"


### PR DESCRIPTION

Hello HassanTAKhan!

It seems like you have npm as one of your (dev-) dependency in blogger.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
